### PR TITLE
Modifications fixing use of parfor for parameter sweeps.

### DIFF
--- a/SimulateModel.m
+++ b/SimulateModel.m
@@ -256,7 +256,7 @@ options=CheckOptions(varargin,{...
 % more options: remove_solve_dir, remove_batch_dir, post_downsample_factor
 
 if options.parallel_flag
-  error('parallel computing has been disabled for debugging. ''set parallel_flag'' to 0');
+  %error('parallel computing has been disabled for debugging. ''set parallel_flag'' to 0');
 end
 
 if options.compile_flag && options.reduce_function_calls_flag==0
@@ -451,14 +451,78 @@ if options.parallel_flag==1
   % or instead: require user to open pool before calling SimulateModel...
 %   parpool(options.num_cores) 
   % run embarrassingly-parallel simulations
+  
+  
+  % Previous parallel code would overwrite the same params.mat file on each
+  % parallel iteration, resulting in the same parameters being used for all
+  % simulations. This code circumvents this issue by assigning a different
+  % study directory to each simulation.
+  
+  % List any core files - these should be deleted, as they are huge (debug)
+  system (['ls ' fullfile(options.study_dir,'output*')],'-echo');
+  system('find * -name "core*"','-echo');
+ 
+  % Generate unique* ID based on date and time (*as long as they dont start on the
+  % exact same second...). Using these unique identfiers will now enable
+  % you to run multiple sims in the same folder.
+  uniqueID = datestr(now,30);
+  
+  
+  for sim = 1:length(modifications_set)
+      mystudydirs{sim} = fullfile(options.study_dir,['output_parfor_' uniqueID '_' num2str(sim)]);                           
+      
+      % Create solve folders as needed
+      if ~exist(mystudydirs{sim},'dir')                
+          mkdir(fullfile(mystudydirs{sim}));           
+          if ~exist(fullfile(mystudydirs{sim},'solve'),'dir') 
+              mkdir(fullfile(mystudydirs{sim},'solve'));           
+          end
+      end
+      
+      
+      [success,msg]=copyfile([strrep(solve_file,'_mex','') '*'],fullfile(mystudydirs{sim},'solve'));    % Copy the mex file into each study directory, to avoid re-compiling
+      if ~success, error(msg); end
+      
+  end
+ 
   clear data
   parfor sim=1:length(modifications_set)
-    data(sim)=SimulateModel(model,'modifications',modifications_set{sim},'solve_file',solve_file,keyvals{:});
+    %data(sim)=SimulateModel(model,'modifications',modifications_set{sim},'solve_file',solve_file,keyvals{:});       % Original parfor code
+    data(sim)=SimulateModel(model,'modifications',modifications_set{sim},keyvals{:},'study_dir',mystudydirs{sim});  % My modification; now specifies a separate study directory for each sim
     disp(sim);
   end
+
+  
+% Clean up files leftover from sim
+% Unfortunately we can't remove the folders due to locked .nfs files.
+% Need to do this manually later...
+  for sim = 1:length(mystudydirs)
+      
+    % Remove any "core" files that might be present and taking up space
+    if exist(fullfile(mystudydirs{sim},'solve'),'dir')
+      delete(fullfile(mystudydirs{sim},'solve','core*'));
+      delete(fullfile(mystudydirs{sim},'solve','params.mat'));
+      delete(fullfile(mystudydirs{sim},'solve','solve_ode*'));
+      %delete(fullfile(mystudydirs{sim},'solve','*'))
+      %rmdir(fullfile(mystudydirs{sim},'solve'));
+      %rmdir(fullfile(mystudydirs{sim}));
+    end
+  end
+  
+  % Delete any output_parfor* directories.
+  rmdir(fullfile(options.study_dir,'output_parfor*'),'s');
+  
+  % Delete any core files in parent directory
+  delete(fullfile(options.study_dir,'core*'));
+  
+  % Verify all core files are deleted
+  [~,result] = system('find * -name "core*"','-echo');
+  if ~isempty(result); fprintf(strcat(result,'\n')); warning('Core files found. Consider deleting to free up space'); end
+  
   % close pool
 %   delete(gcp)
 % todo: sort data sets by things varied in modifications_set
+% todo: Figure out how to delete locked .nfs files
   return
 end
 
@@ -539,7 +603,7 @@ try
       % (i.e., if is first simulation or a search space varying mechanism list)
       if sim==1 || (~isempty(modifications_set{1}) && any(cellfun(@(x)strcmp(x{2},'mechanism_list'),modifications_set)))
         % prepare file that solves the model system
-        if isempty(options.solve_file) || (~exist(options.solve_file,'file') && ~exist([options.solve_file '.mexa64'],'file') &&  ~exist([options.solve_file '.mexa32'],'file'))
+        if isempty(options.solve_file) || (~exist(options.solve_file,'file') && ~exist([options.solve_file '.mexa64'],'file') &&  ~exist([options.solve_file '.mexa32'],'file') && ~exist([options.solve_file '.mexmaci64'],'file'))
           options.solve_file=GetSolveFile(model,studyinfo,options); % store name of solver file in options struct
         end
         % todo: consider providing better support for studies that produce different m-files per sim (e.g., varying mechanism_list)


### PR DESCRIPTION
Working for me! Opens a new folder ('output_parfor*') where 'params.mat' is saved for each simulation in the sweep; cleans up 'ouput_parfor*' folders when simulation is complete.