### PR TITLE
Iss0021 move code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@
 
 DynaSim toolbox for modeling and simulating dynamical systems in Matlab or Octave
 
-Download the DynaSim toolbox:
-`git clone https://github.com/dynasim/dynasim.git`
+Installation:
+
+1. Download the DynaSim toolbox: `git clone
+   https://github.com/dynasim/dynasim.git`
+2. Create a file named `startup.m` located in
+    - If Mac/Linux `<home folder>/Documents/MATLAB`
+    - If Windows `<home folder>\Documents\MATLAB`
+3. Put the below in the file:
+    - If Mac/Linux `addpath(genpath('/path/to/dynasim'))`
+    - If Windows `addpath(genpath('\path\to\dynasim'))`
 
 Documentation:
 - Get started with the demos: [demos/demos.m](https://github.com/DynaSim/DynaSim/blob/master/demos/demos.m)

--- a/demos/tutorial.m
+++ b/demos/tutorial.m
@@ -14,15 +14,10 @@ at the end of the help section to browse through related help documentation.
 
 % Get ready...
 
-% Set path to your copy of the DynaSim toolbox
-dynasim_path='~/code/dynasim';                    
-% add DynaSim toolbox to Matlab path
-addpath(genpath(dynasim_path)); % comment this out if already in path
-
-% Set where to save outputs
-output_directory=fullfile(dynasim_path,'demos','outputs'); 
+% Save outputs in "<DynaSim directory>/demos/outputs"
+output_directory=fullfile(fileparts(fileparts(which(mfilename))),'demos','outputs');
 % move to root directory where outputs will be saved
-cd(output_directory);   
+cd(output_directory);
 
 % Here we go!
 

--- a/functions/CreateBatch.m
+++ b/functions/CreateBatch.m
@@ -118,19 +118,6 @@ dynasim_functions=fullfile(dynasim_path,'functions');
 % locate mechanism files
 [mech_paths,mech_files]=LocateModelFiles(base_model);
 
-% collect paths to add to all jobs (benefit: adding paths to jobs supports m-files stored/associated with mechanism files)
-% add dynasim root path (where functions are located)
-addpaths={dynasim_path,dynasim_functions};
-% add the toolbox models directory and all subdirectories
-  % note: users can store their models as subdirectories of dynasim/models
-  % and incorporate them in their models without worrying about paths.
-addpaths=cat(2,addpaths,fullfile(dynasim_path,'models'));
-%addpaths=regexp(genpath(dynasim_path),':','split');
-if ~isempty(mech_paths)
-  addpaths=cat(2,addpaths,mech_paths); 
-  addpaths=unique(addpaths);
-end
-
 % add paths to studyinfo structure
 studyinfo.paths.dynasim_functions=dynasim_path;
 studyinfo.paths.mechanisms=mech_paths;
@@ -310,10 +297,6 @@ end
     % purpose: write m-file to job_file to run simulations of sim_ids
     % create job file
     fjob=fopen(job_file,'wt');
-    % add paths
-    for p=1:length(addpaths)
-      fprintf(fjob,'addpath %s\n',addpaths{p});
-    end
     % load studyinfo using helper function to avoid busy file errors
     %fprintf(fjob,'studyinfo=CheckStudyinfo(''%s'',''process_id'',%g);\n',study_file,sim_ids(1));
     %fprintf(fjob,'load(''%s'',''studyinfo'');\n',study_file);

--- a/functions/LocateModelFiles.m
+++ b/functions/LocateModelFiles.m
@@ -59,51 +59,33 @@ keep=cellfun(@isempty,regexp(mechanism_list,'[^\w\.\-/]'));
 %keep=cellfun(@isempty,regexp(mechanism_list,'[^\w\.]'));
 mechanism_list=mechanism_list(keep);
 
-% search in dynasim toolbox model directory
-dynasim_path=fileparts(fileparts(which(mfilename))); % root is one level up from directory containing this function
-model_dir=fullfile(dynasim_path,'models'); % models dir is at root level
-search_paths=regexp(genpath(model_dir),':','split'); % look in all dynasim directories
-% add current directory
-search_paths=cat(2,pwd,search_paths); % look in current directory first
-% add Matlab path
-search_paths=cat(2,search_paths,regexp(path,':','split'));
-% exclude .git directories
-keep=cellfun(@isempty,regexp(search_paths,'.git'));
-search_paths=search_paths(keep);
-num_paths=length(search_paths)+1;
-
 % locate mechanism files
 files={};
 if iscellstr(mechanism_list)
   for f=1:length(mechanism_list) % loop over mechanisms
-    for s=1:num_paths
-      % determine name of mechanism file (assuming recommended extensions)
-      if s==num_paths
-        mech=mechanism_list{f};
-      else
-        mech=fullfile(search_paths{s},mechanism_list{f});
-      end
-      if exist(mech,'file')
-        file=mech;
-      elseif exist([mech '.eqns'],'file')
-        file=[mech '.eqns'];
-      elseif exist([mech '.mech'],'file')
-        file=[mech '.mech'];
-      elseif exist([mech '.txt'],'file')
-        file=[mech '.txt'];
-      elseif exist([mech '.m'],'file')
-        file=[mech '.m'];
-      else
-        file='';
-      end
-      % use 'which' to get full filename of file in Matlab path
-      if isempty(fileparts(file)) % file is a name without a path
-        file=which(file);
-      end
-      if ~isempty(file)
-        files{end+1}=file;
-        break;
-      end
+    % determine name of mechanism file (assuming recommended extensions)
+    mech=mechanism_list{f};
+    if exist(mech,'file')
+      file=mech;
+    elseif exist([mech '.eqns'],'file')
+      file=[mech '.eqns'];
+    elseif exist([mech '.mech'],'file')
+      file=[mech '.mech'];
+    elseif exist([mech '.txt'],'file')
+      file=[mech '.txt'];
+    elseif exist([mech '.m'],'file')
+      file=[mech '.m'];
+    else
+      % TODO: Add error catching here!
+      file='';
+    end
+    % use 'which' to get full filename of file in Matlab path
+    if isempty(fileparts(file)) % file is a name without a path
+      file=which(file);
+    end
+    if ~isempty(file)
+      files{end+1}=file;
+      break;
     end
   end
 end

--- a/functions/LocateModelFiles.m
+++ b/functions/LocateModelFiles.m
@@ -85,7 +85,6 @@ if iscellstr(mechanism_list)
     end
     if ~isempty(file)
       files{end+1}=file;
-      break;
     end
   end
 end

--- a/functions/PlotData.m
+++ b/functions/PlotData.m
@@ -218,13 +218,6 @@ options=CheckOptions(varargin,{...
 data=CheckData(data);
 handles=[];
 
-% Check Matlab path to make sure analysis functions can be called
-dynasim_functions=fullfile(fileparts(which(mfilename)),'functions');
-onPath=~isempty(strfind(path,[dynasim_functions, pathsep]));
-if ~onPath
-  addpath(dynasim_functions); % necessary b/c of changing directory for simulation
-end
-
 % todo: add option 'plot_mode' {'trace','image'}
 
 % variables to plot

--- a/functions/SimulateModel.m
+++ b/functions/SimulateModel.m
@@ -350,24 +350,6 @@ if ~isempty(options.plot_functions)
 %   end  
 end
 
-% check path
-dynasim_path=fileparts(which(mfilename));
-onPath=~isempty(strfind(path,[dynasim_path, pathsep]));
-if ~onPath
-  if options.verbose_flag
-    fprintf('adding dynasim directory to Matlab path: %s\n',dynasim_path);
-  end
-  addpath(dynasim_path); % necessary b/c of changing directory for simulation
-end
-dynasim_functions=fullfile(dynasim_path,'functions');
-onPath=~isempty(strfind(path,[dynasim_functions, pathsep]));
-if ~onPath
-  if options.verbose_flag
-    fprintf('adding dynasim functions directory to Matlab path: %s\n',dynasim_functions);
-  end
-  addpath(dynasim_functions); % necessary b/c of changing directory for simulation
-end
-
 %% 1.0 prepare model and study structures for simulation
 
 % handle special case of input equations with vary() statement


### PR DESCRIPTION
This is a Pull Request relevant to #21 to remove any use of `addpath()` in DynaSim, and to simplify `LocateModelFiles.m` so that we can reason about which mechanism files we're loading using the native MATLAB searchpath, which the user can set.

This also removes all hardcoded dependencies on relative code file location with respect to the overall folder hierarchy, except for a few minor instances (e.g. `CheckHostsPath.m` and `CreateBatch.m`). This means we can move `PlotData.m` and `SimulateModel.m` into `functions` finally! hooray
![banderas](https://cloud.githubusercontent.com/assets/661173/22609608/d875f24e-ea2f-11e6-93ae-43a1f0e2e7c4.gif)
