### PR TITLE
iss194_cluster_without_analysis

### DIFF
--- a/functions/dsSimulate.m
+++ b/functions/dsSimulate.m
@@ -312,21 +312,21 @@ if options.compile_flag && ~options.reduce_function_calls_flag
   options.reduce_function_calls_flag=1;
 end
 
-if options.cluster_flag && ~options.save_data_flag
-  options.save_results_flag=1;
-  if options.verbose_flag
-    fprintf('Setting ''save_results_flag'' to 1 for storing results of batch jobs for later access.\n');
-  end
-end
-
 % Make sure that data is either saved to disk, saved to variable, or plotted
-if nargout==0 && ~options.save_data_flag && ~options.save_results_flag && isempty(options.plot_functions)
+if (nargout==0 || options.cluster_flag) && ~options.save_data_flag && ~options.save_results_flag && isempty(options.plot_functions)
   if ~isempty(options.analysis_functions)
     fprintf('Setting ''save_results_flag''=1 since output from dsSimulate is not stored in a variable and analysis functions specified.\n')
     options.save_results_flag = 1;
   else
     fprintf('Setting ''save_data_flag''=1 since output from dsSimulate is not stored in a variable and no plot or analysis functions specified.\n')
     options.save_data_flag = 1;
+  end
+end
+
+if options.cluster_flag && ~options.save_data_flag
+  options.save_results_flag=1;
+  if options.verbose_flag
+    fprintf('Setting ''save_results_flag'' to 1 for storing results of batch jobs for later access.\n');
   end
 end
 


### PR DESCRIPTION
Resolved: save_results_flag was being set to 1 when no analysis_functions were specified.

Edited dsSimulate: switched conditionals setting {save_data_flag and save_results_flag} and added "(nargout==0 || options.cluster_flag)"