### PR TITLE
Resolved: raster plots for sim data with monitored spikes

### DIFF
--- a/functions/dsPlot.m
+++ b/functions/dsPlot.m
@@ -315,6 +315,12 @@ switch options.plot_type
     end
   case {'rastergram','raster'} % raster VARIABLE_spike_times
     if any(cellfun(@isempty,regexp(var_fields,'.*_spike_times$')))
+      rmfields=cellfun(@(x)[x '_spikes'],var_fields,'uni',0);
+      idx=cellfun(@(x)isfield(data,x),rmfields);
+      if any(idx)
+         data=rmfield(data,rmfields);
+         data.labels=setdiff(data.labels,rmfields,'stable');
+      end
       data=dsCalcFR(data,varargin{:});
     end
     xdata=time;


### PR DESCRIPTION
Resolved Issue #205: raster plots for sim data with monitored spikes

Edited dsPlot: fixed rastergram with monitor by removing var_spikes if present in data structure

dsPlot code (add @ line 318):
  rmfields=cellfun(@(x)[x '_spikes'],var_fields,'uni',0);
  idx=cellfun(@(x)isfield(data,x),rmfields);
  if any(idx)
     data=rmfield(data,rmfields);
     data.labels=setdiff(data.labels,rmfields,'stable');
  end