### PR TITLE
preallocate spike times to -1e6 instead of -inf

### DIFF
--- a/functions/internal/dsWriteDynaSimSolver.m
+++ b/functions/internal/dsWriteDynaSimSolver.m
@@ -509,11 +509,10 @@ if ~isempty(model.monitors)
       % initialize spike buffer and buffer index
       if options.save_parameters_flag
         % tspike = -inf(buffer_size,npop):
-        fprintf(fid,'%s = -inf(%g,%s%s_Npop);\n',var_tspikes,spike_buffer_size,parameter_prefix,pop_name);
-        % buffer_index = ones(1,npop):
+        fprintf(fid,'%s = -1e6*ones(%g,%s%s_Npop);\n',var_tspikes,spike_buffer_size,parameter_prefix,pop_name);
         fprintf(fid,'%s = ones(1,%s%s_Npop);\n',var_buffer_index,parameter_prefix,pop_name);
       else
-        fprintf(fid,'%s = -inf(%g,%g);\n',var_tspikes,spike_buffer_size,model.parameters.([pop_name '_Npop']));
+        fprintf(fid,'%s = -1e6*ones(%g,%g);\n',var_tspikes,spike_buffer_size,model.parameters.([pop_name '_Npop']));
         fprintf(fid,'%s = ones(1,%g);\n',var_buffer_index,model.parameters.([pop_name '_Npop']));
       end
       


### PR DESCRIPTION
Resolved Issue #207: Preallocated spike times of -inf produce NaNs in arithmetic operations

Edited dsWriteDynaSimSolver: for tspike preallocation, use -1e6 x ones instead of -inf (lines 512, 515). This avoids producing inf x 0->NaN and preallocates spikes sufficiently far in the past (10sec for dt=.01) to have negligible effects