### PR TITLE
Fix #398 for real this time

### DIFF
--- a/functions/dependencies/ear/lscell.m
+++ b/functions/dependencies/ear/lscell.m
@@ -23,7 +23,7 @@ function dirList = lscell(arg, removePathBool, relativePathBool)
 %
 % See also: DIR
 
-% Dev Note: checked on Mac OS 10.12, Windows 10, Linux with Matlab 2017b
+% Dev Note: checked on Mac OS 10.12, Windows 10, Linux Mint with Matlab 2017b
 
 % parse args
 if ~nargin || isempty(arg)

--- a/functions/dependencies/ear/mfileFnName.m
+++ b/functions/dependencies/ear/mfileFnName.m
@@ -9,7 +9,7 @@ function fnName = mfileFnName
 % Author: Erik Roberts
 
 
-filePath = mfilename('fullpath');
+filePath = evalin('caller', 'mfilename(''fullpath'');');
 
 if ~isempty(strfind(filePath, '+'))
   startInd = regexp(filePath, '\+', 'start');

--- a/functions/dependencies/ear/thisMfileDir.m
+++ b/functions/dependencies/ear/thisMfileDir.m
@@ -7,6 +7,7 @@ function dirPath = thisMfileDir()
 % Usage: dirPath = thisMfileDir()
 
 stack = dbstack;
+% dirPath = evalin('caller', 'fileparts(which(mfilename(''fullpath'')))');
 dirPath = fileparts(which(stack(end).name));
 
 end

--- a/functions/dependencies/ear/wprintf.m
+++ b/functions/dependencies/ear/wprintf.m
@@ -13,7 +13,7 @@ function wprintf(varargin)
 
 str = sprintf(varargin{:});
 
-fprintf(2, ['\nWarning: ' str '\n\n'])
+fprintf(2, ['\nWarning: ' str '\n\n']);
 beep
 
 end

--- a/functions/dependencies/tight_subplot/license.txt
+++ b/functions/dependencies/tight_subplot/license.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2016, Pekka Kumpulainen
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/functions/dependencies/tight_subplot/tight_subplot.m
+++ b/functions/dependencies/tight_subplot/tight_subplot.m
@@ -1,7 +1,8 @@
-function ha = tight_subplot(Nh, Nw, gap, marg_h, marg_w)
+function [ha, pos] = tight_subplot(Nh, Nw, gap, marg_h, marg_w)
+
 % tight_subplot creates "subplot" axes with adjustable gaps and margins
 %
-% ha = tight_subplot(Nh, Nw, gap, marg_h, marg_w)
+% [ha, pos] = tight_subplot(Nh, Nw, gap, marg_h, marg_w)
 %
 %   in:  Nh      number of axes in hight (vertical direction)
 %        Nw      number of axes in width (horizontaldirection)
@@ -14,13 +15,14 @@ function ha = tight_subplot(Nh, Nw, gap, marg_h, marg_w)
 %
 %  out:  ha     array of handles of the axes objects
 %                   starting from upper left corner, going row-wise as in
-%                   subplot.
+%                   subplot
+%        pos    positions of the axes objects
 %
 %  Example: ha = tight_subplot(3,2,[.01 .03],[.1 .01],[.01 .01])
 %           for ii = 1:6; axes(ha(ii)); plot(randn(10,ii)); end
 %           set(ha(1:4),'XTickLabel',''); set(ha,'YTickLabel','')
 
-% Pekka Kumpulainen 20.6.2010   @tut.fi
+% Pekka Kumpulainen 21.5.2012   @tut.fi
 % Tampere University of Technology / Automation Science and Engineering
 
 
@@ -43,7 +45,7 @@ axw = (1-sum(marg_w)-(Nw-1)*gap(2))/Nw;
 
 py = 1-marg_h(2)-axh; 
 
-ha = zeros(Nh*Nw,1);
+% ha = zeros(Nh*Nw,1);
 ii = 0;
 for ih = 1:Nh
     px = marg_w(1);
@@ -58,3 +60,7 @@ for ih = 1:Nh
     end
     py = py-axh-gap(1);
 end
+if nargout > 1
+    pos = get(ha,'Position');
+end
+ha = ha(:);

--- a/functions/dependencies/tight_subplot/tight_subplot2.m
+++ b/functions/dependencies/tight_subplot/tight_subplot2.m
@@ -1,8 +1,9 @@
-function ha = tight_subplot2(Nh, Nw, gap, marg_h, marg_w, hFig)
+function [ha, pos] = tight_subplot2(Nh, Nw, gap, marg_h, marg_w, hFig)
+
 % tight_subplot creates "subplot" axes with adjustable gaps and margins
 %   modified by Erik Roberts to allow figure handle
 %
-% ha = tight_subplot(Nh, Nw, gap, marg_h, marg_w)
+% [ha, pos] = tight_subplot(Nh, Nw, gap, marg_h, marg_w)
 %
 %   in:  Nh      number of axes in hight (vertical direction)
 %        Nw      number of axes in width (horizontaldirection)
@@ -15,20 +16,21 @@ function ha = tight_subplot2(Nh, Nw, gap, marg_h, marg_w, hFig)
 %
 %  out:  ha     array of handles of the axes objects
 %                   starting from upper left corner, going row-wise as in
-%                   going row-wise as in
+%                   subplot
+%        pos    positions of the axes objects
 %
 %  Example: ha = tight_subplot(3,2,[.01 .03],[.1 .01],[.01 .01])
 %           for ii = 1:6; axes(ha(ii)); plot(randn(10,ii)); end
 %           set(ha(1:4),'XTickLabel',''); set(ha,'YTickLabel','')
 
-% Pekka Kumpulainen 20.6.2010   @tut.fi
+% Pekka Kumpulainen 21.5.2012   @tut.fi
 % Tampere University of Technology / Automation Science and Engineering
 
 
 if nargin<3 || isempty(gap); gap = .02; end
 if nargin<4 || isempty(marg_h); marg_h = .05; end
 if nargin<5 || isempty(marg_w); marg_w = .05; end
-if nargin<6; hFig = gcf; end
+if nargin<6 || isempty(hFig); hFig = gcf; end
 
 if numel(gap)==1
     gap = [gap gap];
@@ -45,7 +47,7 @@ axw = (1-sum(marg_w)-(Nw-1)*gap(2))/Nw;
 
 py = 1-marg_h(2)-axh;
 
-ha = zeros(Nh*Nw,1);
+% ha = zeros(Nh*Nw,1);
 ii = 0;
 for ih = 1:Nh
     px = marg_w(1);
@@ -68,3 +70,7 @@ for ih = 1:Nh
     end
     py = py-axh-gap(1);
 end
+if nargout > 1
+    pos = get(ha,'Position');
+end
+ha = ha(:);


### PR DESCRIPTION
This fix to #398 includes both @erik-robert's bug-fix AND @kupiqu's
Octave plotting check, so everyone should be happy. I tested this and it
worked correctly when running a simulation using these plotting
arguments:

```
'plot_functions',{@dsPlot,@dsPlot,@dsPlot},...
'plot_options',{{'plot_type','waveform','format','png'},...
                {'plot_type','rastergram','format','png'},...
                {'plot_type','power','format','png','xlim',[0 40]}});
```

Please post on #398 if you're still having issues with `dsPlot`.

On branch iss398_again
You are currently cherry-picking commit c50b2d8.
Changes to be committed:
	modified:   functions/dependencies/ear/lscell.m
	modified:   functions/dependencies/ear/mfileFnName.m
	modified:   functions/dependencies/ear/thisMfileDir.m
	modified:   functions/dependencies/ear/wprintf.m
	new file:   functions/dependencies/tight_subplot/license.txt
	renamed:    functions/dependencies/tight_subplot.m -> functions/dependencies/tight_subplot/tight_subplot.m
	renamed:    functions/dependencies/ear/tight_subplot2.m -> functions/dependencies/tight_subplot/tight_subplot2.m