### PR TITLE
RNG fixes

### DIFF
--- a/functions/dependencies/Octave/rng_octave.m
+++ b/functions/dependencies/Octave/rng_octave.m
@@ -1,40 +1,91 @@
-function [rand_seed,randn_seed] = rng_octave(x)
-%rng_octave(x) establishes the seed for the random number generator of rand and randn
+function out = rng_octave(x)
+%rng_octave(x) establishes the seed and reports seed and state for the random number generator of rand, rande, randg, randn and randp
 %x must be:
-%- a numeric value that sets the seed value
+%- a numeric value that sets the seed value of the rng
 %- 'shuffle': it seeds rng based on current time
-%- 'default': it sets the seed = 0
-%- 'seed': it reports the seed of the rng
-%- 'state': it reports the state of the rng, so can be replicated afterwards
+%- 'default': it sets the seed = 0 (actually 5489 for Matlab compatibility)
 %if x is empty or missing, rng returns the seed of the random number generator
 
   errmsg = 'only a single numeric or limited string argument is supported, type help rng_octave for details';
 
-  if nargin > 1
+  if nargin == 0
+    x = [];
+  elseif nargin > 1
     error(errmsg);
-  elseif nargin < 1 || isempty(x)
-    x = 'seed';
   elseif ischar(x)
     if strcmp(x,'shuffle')
-      x = now;
+      tnow = clock;
+      x = 1e6*tnow(end);
     elseif strcmp(x,'default')
       x = 0;
-    elseif ~strcmp(x,'seed') && ~strcmp(x,'state')
+    else
       error(errmsg);
     end
   elseif ~isnumeric(x)
     error(errmsg);
   end
-  if strcmp(x,'seed')
-    rand_seed = rand('seed');
-    randn_seed = randn('seed');
-  elseif strcmp(x,'state')
-    rand_seed = rand('state');
-    randn_seed = randn('state');
+
+  if isempty(x)
+    rand_seed = uint32(rand('seed'));
+    rande_seed = uint32(rande('seed'));
+    randg_seed = uint32(randg('seed'));
+    randn_seed = uint32(randn('seed'));
+    randp_seed = uint32(randp('seed'));
+    if isequal(rand_seed,rande_seed,randg_seed,randn_seed,randp_seed)
+      out.Seed = rand_seed;
+    else
+      out.rand_seed = rand_seed;
+      out.rande_seed = rande_seed;
+      out.randg_seed = randg_seed;
+      out.randn_seed = randn_seed;
+      out.randp_seed = randp_seed;
+    end
+    rand_state = uint32(rand('state'));
+    rande_state = uint32(rande('state'));
+    randg_state = uint32(randg('state'));
+    randn_state = uint32(randn('state'));
+    randp_state = uint32(randp('state'));
+    if isequal(rand_state,rande_state,randg_state,randn_state,randp_state)
+      out.State = rand_state;
+    else
+      out.rand_state = rand_state;
+      out.rande_state = rande_state;
+      out.randg_state = randg_state;
+      out.randn_state = randn_state;
+      out.randp_state = randp_state;
+    end
   else
-    rand_seed = x;
-    randn_seed = x;
-    rand('seed',x);
-    randn('seed',x);
+    out.Seed = uint32(x);
+    out.State = twister_state(out.Seed);
+    rand('seed',out.Seed);
+    rande('seed',out.Seed);
+    randg('seed',out.Seed);
+    randn('seed',out.Seed);
+    randp('seed',out.Seed);
+    rand('state',out.State);
+    rande('state',out.State);
+    randg('state',out.State);
+    randn('state',out.State);
+    randp('state',out.State);
+  end
+  out.Type = 'twister';
+
+  % states in Octave and Matlab are different, this fixes the difference for rand
+  % current limitations:
+  % - unfortunately it does not seem to work for matching randn
+  % - in Matlab, the same rng applies to rand and randn, whereas in Octave each one evolves in its way. This means that in Matlab rand, randn and randn, rand give different series, whereas in Octave they are the same
+  function state = twister_state(seed)
+    if nargin < 1 || seed == 0
+      seed = 5489; % for Matlab compatibility, 0 and 'default' actually corresponds to seed 5489 in Matlab
+    end
+    state = uint32(zeros(625,1));
+    state(1) = seed;
+    for N = 1:623
+        %% initialize_generator
+        % bit-xor (right shift by 30 bits)
+        uint64(1812433253)*uint64(bitxor(state(N),bitshift(state(N),-30)))+N; % has to be uint64, otherwise in 4th iteration hit maximum of uint32!
+        state(N+1) = uint32(bitand(ans,uint64(intmax('uint32')))); % untempered numbers
+    end
+    state(end) = 1; % Matlab displays 624 here, but for compatibility, this has to be set to 1
   end
 end

--- a/functions/dependencies/rng_wrapper.m
+++ b/functions/dependencies/rng_wrapper.m
@@ -5,28 +5,17 @@ function out = rng_wrapper(in,varargin)
 % Copyright (C) 2016 Jason Sherfey, Boston University, USA
 
 if strcmp(reportUI,'matlab')
-  if nargin == 0
-    out = rng;
-  elseif isempty(varargin)
-    out = rng(in);
-  else
-    out = rng(in,varargin{:});
+  if nargin > 0 && isempty(varargin)
+    rng(in);
+  elseif nargin > 0
+    rng(in,varargin{:});
   end
+  out = rng;
 else
-  out.Type = 'twister'; % only one supported
-  if nargin == 0
-    [rand_seed, randn_seed] = rng_octave;
-    if rand_seed ~= randn_seed
-      rng_octave(rand_seed);
-    end
-    out.Seed = rand_seed;
-    out.State = rng_octave('state');
-  else
-    if ~isempty(varargin)
-      warning('varargin ignored: Octave only supports the twister generator');
-    end
-    [rand_seed, randn_seed] = rng_octave(in);
-    out.Seed = rand_seed;
-    out.State = rng_octave('state');
+  if nargin > 0 && isempty(varargin)
+    rng_octave(in);
+  elseif nargin > 0
+    rng_octave(in,varargin{:});
   end
+  out = rng_octave;
 end


### PR DESCRIPTION
This started trying to have exactly the same results in Octave and Matlab when running a simulation with noise. It ended up being impossible because of internal differences between Matlab and Octave (mainly because of centralized RNG in Matlab vs. decentralized in Octave, but also because Matlab and Octave do not implement the Ziggurat transformation in the same way). 

Anyway, while learning about this, I could fix few bugs and improve the code to be more alike between the two systems. This will facilitate future maintainance, should Octave implement a centralized RNG, and/or if the Ziggurat transformation is changed to match Matlab.