### PR TITLE
allowing whitespace between function variables

### DIFF
--- a/functions/internal/dsClassifyEquation.m
+++ b/functions/internal/dsClassifyEquation.m
@@ -151,7 +151,7 @@ if isempty(class) && ~isempty(regexp(string,pattern,'once','ignorecase'))
 end
 
 % function check: f(vars)=exression
-pattern='^\w+\([@a-zA-Z][\w,@]*\)\s*=';
+pattern='^\w+\([@a-zA-Z][\w,\s+@]*\)\s*='; % allowing whitespace between variables
 if isempty(class) && ~isempty(regexp(string,pattern,'once'))
   class='function';
 end


### PR DESCRIPTION
We can now define a function like this (note the whitespace between t and V):

`f(t, V) = ...`