### PR TITLE
explicitly define varargin as requested by dynasim

### DIFF
--- a/functions/internal/dsImportModel.m
+++ b/functions/internal/dsImportModel.m
@@ -46,7 +46,7 @@ end
 % download model if source host is known
 switch host
  case {'infbrain','infinitebrain','ib'}
-   source=downloadModel(ModelID);
+   source=downloadModel(ModelID,varargin);
 end
 
 % ------------------------------------------------------------------
@@ -191,7 +191,7 @@ function modl=add_missing_ICs(modl,popname)
     end
   end
 
-function source=downloadModel(ModelID)
+function source=downloadModel(ModelID,varargin)
 % Set path to your MySQL Connector/J JAR
 jarfile = '/usr/share/java/mysql-connector-java.jar';
 javaaddpath(jarfile); % WARNING: this might clear global variables


### PR DESCRIPTION
I also had an error from matlab 2020a that said 
```
Error: File: dsImportModel.m Line: 236 Column: 43
Invalid syntax for calling function 'varargin' on the path. Use a valid syntax or explicitly
initialize 'varargin' to make it a variable.
```
Defining `varargin` explicitly in `dsImportModel` solved the issue for me.